### PR TITLE
Replace (>= 0 n) with (pos? n)

### DIFF
--- a/src/blizzard/core.clj
+++ b/src/blizzard/core.clj
@@ -50,7 +50,7 @@
 (defn n-or-1
   "Returns n if n is greater than 0 otherwise 1."
   [n]
-  (if (>= 0 n) 1 n))
+  (if (pos? n) n 1))
 
 (defn n-or-max-ids
   "Returns n if n is equal to or less than max-ids."


### PR DESCRIPTION
`(pos? n)` reads more clearly than `(>= 0 n)`, in my opinion.
# 

Thanks, @maxcountryman, for this and [flake](https://github.com/maxcountryman/flake).

While I don't get to use Erlang day-to-day, I love seeing the concepts implemented in Clojure.

[dire](https://github.com/MichaelDrogalis/dire) is great too!
